### PR TITLE
add UI for creating AOI

### DIFF
--- a/frontend/src/components/AOI.vue
+++ b/frontend/src/components/AOI.vue
@@ -1,0 +1,29 @@
+<template>
+<v-col
+    cols="10"
+    sm="1"
+    style= "position: absolute; right: 0; top: 60px;z-index:999"
+>
+    <v-select
+        :items="['get', 'retrieve']"
+        label="building"
+        variant="outlined"
+        @update:modelValue="sendBuildingRequest"
+    ></v-select>
+   
+   
+</v-col>
+
+
+</template>
+
+<script setup>
+
+const sendBuildingRequest = (e)=>{
+    console.log(e)
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -22,6 +22,8 @@
         </v-btn>
       </v-row>
 
+
+      <AOI />
     </div>
   </div>
 </template>
@@ -34,6 +36,7 @@ import { HTTP } from '../utils/http-common';
 import {TreeModel} from '../utils/TreeModel';
 import {MapboxLayer} from '@deck.gl/mapbox';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
+import AOI from './AOI.vue';
 
 
 


### PR DESCRIPTION
A minimal and temporary user interface for initializing the scene. 
It includes a simple select form for each scene element (tree, building, etc) which has get and retrieve options.
The scenario is as follows:

- By selecting the "get" option, the corresponding API in the backend is called which gets the data from OSM (overpass API) and generates the targetted table.
- By selecting the "retrieve" option, the data are fetched from the database and visualized in the frontend.

After creating all the scene elements, this component can be deleted.