### PR TITLE
UCD-38-show-buildings: save and retrieve buildings

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -26,3 +26,51 @@ def get_table_names():
   cur.close()
   conn.close()
   return tables
+
+
+def init_building_table():
+  connection = connect()
+  cursor = connection.cursor()
+  create_building_table_query =''' 
+        drop table if exists building;
+        create table building (id SERIAL PRIMARY KEY, wallcolor CHAR(7), wallmaterial VARCHAR(20), roofcolor CHAR(7), roofmaterial VARCHAR(20), roofshape VARCHAR(20), roofheight FLOAT(4), height FLOAT(4), floors FLOAT, estimatedheight FLOAT(4), geom geometry(Geometry, 4326));
+  '''
+  cursor.execute(create_building_table_query)
+
+  connection.commit()
+  cursor.close()
+  connection.close()
+  return "ok"
+
+def get_buildings_from_osm(wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom):
+  connection = connect()
+  cursor = connection.cursor()
+  
+  insert_query_building= '''
+        INSERT INTO building (wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326));
+
+  '''
+  cursor.execute(insert_query_building, (wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom,))
+
+  connection.commit()
+  cursor.close()
+  connection.close()
+  return "ok"
+
+def get_buildings_from_db():
+  connection = connect()
+  cursor = connection.cursor()
+  get_building_query =''' select json_build_object(
+        'type', 'FeatureCollection',
+        'features', json_agg(ST_AsGeoJSON(building.*)::json)
+        )
+        from building
+      ;
+  '''
+  cursor.execute(get_building_query)
+  building = cursor.fetchall()[0][0]
+  cursor.close()
+  connection.close()
+  return building
+
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 import json
-from db import get_table_names
+import requests
+from db import get_table_names, get_buildings_from_osm, init_building_table, get_buildings_from_db
 
 app = FastAPI()
 origins = [
@@ -38,3 +39,65 @@ async def root():
         raise HTTPException(status_code=500, detail=f"Something went wrong: {err}")
     
     
+@app.post("/get-buildings-from-osm")
+async def get_buildings_from_osm_api(request: Request):
+    data = await request.json()
+    init_building_table()
+    xmin = data['bbox']["xmin"]
+    ymin = data['bbox']["ymin"]
+    xmax = data['bbox']["xmax"]
+    ymax = data['bbox']["ymax"]
+    overpass_url = "http://overpass-api.de/api/interpreter"
+    overpass_query_building = """
+        [out:json];
+        way["building"](%s,%s,%s,%s);
+        convert item ::=::,::geom=geom(),_osm_type=type();
+        out geom;
+    """ % ( ymin, xmin, ymax ,xmax )
+
+    response_building = requests.get(overpass_url, 
+                        params={'data': overpass_query_building})
+    
+    data_building = response_building.json()
+
+    for f in data_building["elements"]:
+        f["geometry"]["type"] = "Polygon"
+        f["geometry"]["coordinates"] = [f["geometry"]["coordinates"]]
+    
+    for f in data_building["elements"]:
+        wallcolor= None
+        if 'building:colour' in f['tags']:  wallcolor = f['tags']['building:colour']
+        wallmaterial= None
+        if 'building:material' in f['tags']: wallmaterial =f['tags']['building:material']
+        roofcolor=None
+        if 'roof:colour' in f['tags']: roofcolor =f['tags']['roof:colour']
+        roofmaterial=None
+        if 'roof:material' in f['tags']: roofmaterial =f['tags']['roof:material']
+        roofshape=None
+        if 'roof:shape' in f['tags']: roofshape =f['tags']['roof:shape']
+        roofheight=None
+        if 'roof:height' in f['tags']: roofheight =f['tags']['roof:height']
+        height=None
+        if 'height' in f['tags']: height =f['tags']['height']
+        floors= None
+        if 'building:levels' in f['tags']: floors =f['tags']['building:levels']
+
+        estimatedheight= None
+        if height is not None:
+            estimatedheight = float(height)
+        elif floors is not None:
+            estimatedheight = float(floors)*3.5
+        else:
+            estimatedheight = 15
+
+
+        geom=json.dumps(f['geometry'])
+
+        get_buildings_from_osm(wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom)
+    
+    
+    return "fine"
+
+@app.get("/get-buildings-from-db")
+async def get_buildings_from_db_api():
+    return get_buildings_from_db()

--- a/frontend/src/components/AOI.vue
+++ b/frontend/src/components/AOI.vue
@@ -18,9 +18,11 @@
 </template>
 
 <script setup>
+import {useStore} from "vuex";
+const store = useStore();
 
 const sendBuildingRequest = (e)=>{
-    console.log(e)
+    e == "get" ? store.dispatch("aoi/getbuildingsFromOSM") : store.dispatch("aoi/getbuildingsFromDB")
 }
 </script>
 

--- a/frontend/src/store/modules/aoi.js
+++ b/frontend/src/store/modules/aoi.js
@@ -1,13 +1,51 @@
+import { HTTP } from '../../utils/http-common';
+import {GeoJsonLayer} from '@deck.gl/layers';
+import {MapboxLayer} from '@deck.gl/mapbox';
+
 const aoi = {
     namespaced: true,
     state: {
-        bbox : {xmin: 13.742725, ymin: 51.059803, xmax: 13.756758, ymax: 51.066950}
+        bbox : {xmin: 13.742725, ymin: 51.059803, xmax: 13.756758, ymax: 51.066950},
+        overpassBuildings: null,
 
     },
     mutations:{
 
     },
     actions:{
+        getbuildingsFromOSM({state}){
+            HTTP
+            .post('get-buildings-from-osm', {
+                bbox : state.bbox
+            })
+        },
+        getbuildingsFromDB({state, rootState}){
+            HTTP
+            .get('get-buildings-from-db')
+            .then(response=>{
+                console.log(response)
+                state.overpassBuildings = new MapboxLayer({
+                    id: 'overpass_buildings',
+                    type: GeoJsonLayer,
+                    data: response.data.features,
+                    opacity: 1,
+                    stroked: false,
+                    filled: true,
+                    extruded: true,
+                    wireframe: false,
+                    getElevation: f => f.properties.estimatedheight,
+                    getFillColor: [235, 148, 35, 255],
+                    getLineColor: [0, 0, 0],
+                    wireframe: true,
+                    pickable: true,
+                    
+                });
+                rootState.map.map.addLayer(state.overpassBuildings);
+                rootState.map.map.on('click', 'overpass_buildings', (e) => {
+                    console.log(e)
+                })
+            })
+        },
 
     },
     getters:{


### PR DESCRIPTION
- Query data from overpass API and insert it into the "building" table. The search query is limited to the pre-defined bounding box.
- Retrieve buildings and visualize them in the  frontend using DeckGL