### PR TITLE
solvue warning: vue reactivity

### DIFF
--- a/frontend/src/components/Contribution.vue
+++ b/frontend/src/components/Contribution.vue
@@ -34,9 +34,9 @@ const props =
 
 const commentModeEnabled = ref(false)
 const lineDrawToggle =  ref(false)
-let draw = reactive (null)
-let drawnLineGeometry = reactive (null)
-let drawnPathlayer = reactive (null)
+let draw = reactive ({})
+let drawnLineGeometry = reactive ({})
+let drawnPathlayer = reactive ({})
 let drawnPathlayerId = ref (null)
 
 


### PR DESCRIPTION
Solves warning appeared on the console due to the reactive data declaration.
The reactive data cannot be initialized as null. Instead, they can be initialized as an (empty) array or object.