### PR TITLE
delete table rows in get request from osm

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -237,3 +237,39 @@ def get_driving_lane_polygon_from_db():
   cursor.close()
   connection.close()
   return driving_lane_polygon
+
+def drop_greenery_table():
+  connection = connect()
+  cursor = connection.cursor()
+  drop_greenery_table_query =''' delete from greenery;'''
+  cursor.execute(drop_greenery_table_query)
+  connection.commit()
+  cursor.close()
+  connection.close()
+  
+def drop_building_table():
+  connection = connect()
+  cursor = connection.cursor()
+  drop_building_table_query =''' delete from building;'''
+  cursor.execute(drop_building_table_query)
+  connection.commit()
+  cursor.close()
+  connection.close()
+
+def drop_tree_table():
+  connection = connect()
+  cursor = connection.cursor()
+  drop_tree_table_query =''' delete from tree;'''
+  cursor.execute(drop_tree_table_query)
+  connection.commit()
+  cursor.close()
+  connection.close()
+
+def drop_driving_lane_table():
+  connection = connect()
+  cursor = connection.cursor()
+  drop_driving_lane_table_query =''' delete from driving_lane tree; delete from driving_lane_polygon'''
+  cursor.execute(drop_driving_lane_table_query)
+  connection.commit()
+  cursor.close()
+  connection.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,11 @@ from db import (
     undislike_comment,
     unlike_comment,
     get_driving_lane_from_db,
-    get_driving_lane_polygon_from_db
+    get_driving_lane_polygon_from_db,
+    drop_greenery_table,
+    drop_building_table,
+    drop_tree_table,
+    drop_driving_lane_table
 )
 from db_migrations import run_database_migrations
 
@@ -68,6 +72,7 @@ async def root():
 
 @app.post("/store-greenery-from-osm")
 async def store_greenery_from_osm_api(request: Request):
+    drop_greenery_table()
     data = await request.json()
     xmin = data["bbox"]["xmin"]
     ymin = data["bbox"]["ymin"]
@@ -139,6 +144,7 @@ async def get_greenery_from_db_api():
 
 @app.post("/get-buildings-from-osm")
 async def get_buildings_from_osm_api(request: Request):
+    drop_building_table()
     data = await request.json()
     xmin = data["bbox"]["xmin"]
     ymin = data["bbox"]["ymin"]
@@ -263,6 +269,7 @@ async def get_buildings_from_db_api():
 
 @app.post("/get-trees-from-osm")
 async def get_trees_from_osm_api(request: Request):
+    drop_tree_table()
     data = await request.json()
     xmin = data["bbox"]["xmin"]
     ymin = data["bbox"]["ymin"]
@@ -287,7 +294,7 @@ async def get_trees_from_osm_api(request: Request):
     connection = connect()
     cursor = connection.cursor()
     insert_query_tree = """
-            INSERT INTO tree (geom) VALUES (ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326));
+        INSERT INTO tree (geom) VALUES (ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326));
 
     """
     for f in data_tree["elements"]:
@@ -360,6 +367,7 @@ async def undislike_comment_api(request: Request):
 
 @app.post("/get-driving-lane-from-osm")
 async def get_driving_lane_from_osm_api(request: Request):
+    drop_driving_lane_table()
     data = await request.json()
     xmin = data['bbox']["xmin"]
     ymin = data['bbox']["ymin"]


### PR DESCRIPTION
This feature deletes all the rows while inserting data from osm to the table, to avoid inserting duplicated features on the same table in the development process.

This feature can be optimized or deleted in the future.