### PR TITLE
Feat/buildings smooth edge

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -190,10 +190,9 @@ async def get_buildings_from_osm_api(request: Request):
 
     connection = connect()
     cursor = connection.cursor()
-
+       # INSERT INTO building (wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326));
     insert_query_building = """
-        INSERT INTO building (wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326));
-
+        INSERT INTO building (wallcolor,wallmaterial, roofcolor,roofmaterial,roofshape,roofheight, height, floors, estimatedheight, geom) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, (st_buffer(st_buffer(ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326)::geography, 1,'side=right'),1)::geography)::geometry);
     """
     for f in data_building["elements"]:
         f["geometry"]["type"] = "Polygon"

--- a/frontend/src/service/backend.service.js
+++ b/frontend/src/service/backend.service.js
@@ -6,21 +6,39 @@ import store from "../store/store";
 
 export async function getbuildingsFromDB() {
   const response = await HTTP.get('get-buildings-from-db');
-  console.log(response);
+  const emptygeom = d => d.geometry.coordinates.length== 1;
+  const nonEmptyFeatures = response.data.features.filter(emptygeom);
+  const colorPalette = [[123, 222, 242, 255], [178, 247, 239, 255],[239, 247, 246,255], [247, 214, 224, 255], [242, 181, 211,255]];
+
   return new MapboxLayer({
     id: 'overpass_buildings',
     type: PolygonLayer,
-    data: response.data.features,
+    data: nonEmptyFeatures,
     getPolygon: d => d.geometry.coordinates,
-    opacity: 1,
     stroked: false,
     filled: true,
     extruded: true,
-    wireframe: false,
     getElevation: f => f.properties.estimatedheight,
-    getFillColor: [235, 148, 35, 255],
-    getLineColor: [0, 0, 0],
-    wireframe: true,
+    getFillColor: d => {
+      if (d.properties.estimatedheight<=4){
+        return colorPalette[0]
+      }
+      else if (d.properties.estimatedheight>4 && d.properties.estimatedheight<=8){
+        return colorPalette[1]
+      }
+      else if (d.properties.estimatedheight>8 && d.properties.estimatedheight<=12){
+        return colorPalette[2]
+      }
+      else if (d.properties.estimatedheight>12 && d.properties.estimatedheight<=16){
+        return colorPalette[3]
+      }
+      else {
+        return colorPalette[4]
+      }
+      
+    },
+    getLineColor: [0, 0, 0, 0],
+    wireframe: false,
     pickable: true,
   })
 }


### PR DESCRIPTION
The following features have been implemented:

- Generate round and smooth edges for the building geometries coming from OSM
- The geometry generation has been done using PostGIS buffer function (1 meter shrink then expand).
- It preserves the actual dimension of the geometry
- The buildings are visualized using a pastel color palette based on their height information
- The chosen color palette is as follows (with the color code): 
<img width="404" alt="Screenshot 2022-09-06 at 11 26 26" src="https://user-images.githubusercontent.com/50631096/188599196-270825eb-17be-4353-a17a-9af90b6280a0.png">

color code (from left to right): [[123, 222, 242, 255], [178, 247, 239, 255],[239, 247, 246,255], [247, 214, 224, 255], [242, 181, 211,255]];
