### PR TITLE
feat: disable recursive map repaint calls inside of the custom threejs layer

### DIFF
--- a/frontend/src/utils/TreeModel.js
+++ b/frontend/src/utils/TreeModel.js
@@ -53,7 +53,6 @@ export const TreeModel = (lng, lat, id)=> {
           (gltf) => {
             console.log(gltf)
             this.scene.add(gltf.scene);
-            
           }
         );
 
@@ -67,6 +66,7 @@ export const TreeModel = (lng, lat, id)=> {
         });
  
         this.renderer.autoClear = false;
+        console.count("onAdd")
       },
 
 
@@ -106,7 +106,8 @@ export const TreeModel = (lng, lat, id)=> {
         //this.renderer.state.reset();
         this.renderer.resetState();
         this.renderer.render(this.scene, this.camera);
-        this.map.triggerRepaint();
+        console.count("triggerRepaint")
+        //this.map.triggerRepaint();
       }
   };
 


### PR DESCRIPTION
Don't call the map's repaint method inside of the custom layer's render function because it calls the render method on all layers :)
