### PR TITLE
initialize project table

### DIFF
--- a/backend/db_migrations/0003.project-table-initialization.sql
+++ b/backend/db_migrations/0003.project-table-initialization.sql
@@ -1,0 +1,3 @@
+drop table if exists project;
+create table project (project_id TEXT unique, project_name TEXT, aoi jsonb);
+insert into project (project_id, project_name, aoi) values ('0','Mainz', '{"xmin": 8.24287, "ymin": 49.992401, "xmax": 8.29617, "ymax": 50.018199}');


### PR DESCRIPTION
Creates a table for the initialization of the project, which includes the project name, id, and bounding box of the project.

The table has been created as follows:

_create table project (project_id TEXT unique, project_name TEXT, aoi jsonb);_


In which the project id is text type and unique, and AOI is a json type