### PR TITLE
navigate to the planning idea with animation

### DIFF
--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -14,7 +14,7 @@
         </v-btn>
       </v-row>
       <AOI @addLayer="addLayerToMap" @addImage="addImageToMap" />
-      <PlanningIdeas @activateSelectedPlanningIdea="activateSelectedPlanningIdeaInMap" />
+      <PlanningIdeas @activateSelectedPlanningIdea="activateSelectedPlanningIdeaInMap" @planningData="planningData" />
       <Quests />
       <Contribution @addPopup="addPopupToMap" @addDrawControl="addDrawControl" @addDrawnLine="addDrawnLine"
         @removeDrawnLine="removeDrawnLine" @removeDrawControl="removeDrawControl"
@@ -77,7 +77,17 @@ onMounted(() => {
     maxZoom: store.state.map.maxZoom,
     maxPitch: store.state.map.maxPitch,
   });
+  
+  
   map.on("load", function () {
+    const projectBBOX = [
+      store.state.aoi.projectSpecification.bbox.xmin,
+      store.state.aoi.projectSpecification.bbox.ymin,
+      store.state.aoi.projectSpecification.bbox.xmax,
+      store.state.aoi.projectSpecification.bbox.ymax
+    ]
+    map.fitBounds(projectBBOX);
+    
     HTTP.get("").then((response) => {
       // console.log(response);
     })
@@ -275,6 +285,18 @@ const activateSelectedPlanningIdeaInMap = (selectedFeature)=>{
     )
 
   }
+  
+}
+
+const planningData = (planningIdeaBBOX) => {
+
+  setTimeout(()=>{
+      map.fitBounds(planningIdeaBBOX,{
+        pitch:60,
+        duration: 3000,
+        curve: 4,
+      });
+  }, 2000);
   
 }
 

--- a/frontend/src/components/PlanningIdeas.vue
+++ b/frontend/src/components/PlanningIdeas.vue
@@ -26,13 +26,15 @@
 <script lang="ts" setup>
 import { onMounted, reactive } from "vue";
 import { useStore } from "vuex";
+import bbox from "@turf/bbox";
 import {
   getRoutesFromDB
 } from "../service/backend.service";
 
+
 const store = useStore();
 
-const emit = defineEmits(["activateSelectedPlanningIdea"])
+const emit = defineEmits(["activateSelectedPlanningIdea", "planningData"])
 let planningData = reactive ({ routes: [] })
 
 const addRouteToMap = async () => {
@@ -48,8 +50,6 @@ const sendRouteRequest = async () => {
     const routeData = await getRoutesFromDB(store.state.aoi.projectSpecification.project_id)
    
     planningData.routes = routeData.data
-
-
     store.commit("map/addSource", {
       id: "routes",
       geojson: {
@@ -90,6 +90,9 @@ const sendRouteRequest = async () => {
         "text-size": 10
       }
     })
+
+    const planningIdeaBBOX = bbox(routeData.data);
+    emit("planningData", planningIdeaBBOX)
 
 
 };


### PR DESCRIPTION
This PR adds the following features:

- set the initial view of the map to the whole bounding box of the project
- then navigates to the bounding box of the planning ideas with animation with the following specifications:
{
        pitch:60,
        duration: 3000,
        curve: 4
}
