### PR TITLE
remove maplibre attribution control

### DIFF
--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -88,6 +88,7 @@ onMounted(() => {
     minZoom: store.state.map.minZoom,
     maxZoom: store.state.map.maxZoom,
     maxPitch: store.state.map.maxPitch,
+    attributionControl: false
   });
 
 


### PR DESCRIPTION
Remove map attribution control on the bottom-right of the map