### PR TITLE
keeping current bearing angel and set a fixed pitch in route filter

### DIFF
--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -426,9 +426,9 @@ const removePulseLayerFromMap = (layerid: string) => {
 
 
 const activateSelectedPlanningIdeaInMap = (selectedFeature: Feature) => {
-
+  const currentBearing = map.getBearing();
   let bounds = turf.bbox(selectedFeature) as LngLatBoundsLike;
-  map.fitBounds(bounds, { padding: 20 });
+  map.fitBounds(bounds, { pitch: 40, bearing: currentBearing, padding: 40 });
 
   // @ts-ignore
   if (selectedFeature.type == 'FeatureCollection') {


### PR DESCRIPTION
This PR keeps the current map-bearing angel and set a fixed pitch in the route filter