### PR TITLE
Ucd 321 visualize rails

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -323,6 +323,15 @@ def drop_traffic_signal_table(projectId):
   cursor.close()
   connection.close()
 
+def drop_tram_line_table(projectId):
+  connection = connect()
+  cursor = connection.cursor()
+  drop_tram_line_table_query =f''' delete from tram_line where project_id='{projectId}';'''
+  cursor.execute(drop_tram_line_table_query)
+  connection.commit()
+  cursor.close()
+  connection.close()
+
 def get_traffic_signal_from_db(projectId):
   connection = connect()
   cursor = connection.cursor()
@@ -363,6 +372,23 @@ def get_routes_from_db(projectId):
       ;
   '''
   cursor.execute(get_routes_query)
+  routes = cursor.fetchall()[0][0]
+  cursor.close()
+  connection.close()
+  return routes
+
+def get_tram_line_from_db(projectId):
+  connection = connect()
+  cursor = connection.cursor()
+  get_tram_line_query = f''' select json_build_object(
+        'type', 'FeatureCollection',
+        'features', json_agg(ST_AsGeoJSON(tram_line.*)::json)
+        )
+        from tram_line
+        where project_id = '{projectId}'
+      ;
+  '''
+  cursor.execute(get_tram_line_query)
   routes = cursor.fetchall()[0][0]
   cursor.close()
   connection.close()

--- a/backend/db_migrations/0001.create-initial-tables.sql
+++ b/backend/db_migrations/0001.create-initial-tables.sql
@@ -15,3 +15,5 @@ create table if not exists driving_lane_polygon (id SERIAL PRIMARY KEY, lanes te
 create table if not exists routes (id SERIAL PRIMARY KEY, title VARCHAR (300), color CHAR(7), width FLOAT(2),geom geometry(LINESTRING, 4326));
 
 create table if not exists traffic_signal (id SERIAL PRIMARY KEY, geom geometry(Point, 4326));
+
+create table if not exists tram_line (id SERIAL PRIMARY KEY, project_id TEXT, lane_name text, starts_from text, arrives_to text, geom geometry(Geometry, 4326));

--- a/frontend/src/components/AOI.vue
+++ b/frontend/src/components/AOI.vue
@@ -6,7 +6,7 @@
 import { onMounted, computed } from "vue";
 import { useStore } from "vuex";
 import {
-  getbuildingsFromDB, getDrivingLaneFromDB, getGreeneryFromDBTexture, getTrafficSignalFromDB, getTreesFromDB, getTreeJsonFromDB, getTreesFromOSM
+  getbuildingsFromDB, getDrivingLaneFromDB, getGreeneryFromDBTexture, getTrafficSignalFromDB, getTreesFromDB, getTreeJsonFromDB, getTreesFromOSM, getTramLineDataFromDB
 } from "../service/backend.service";
 import { TreeModel } from "../utils/TreeModel";
 import DevUI from "@/components/DevUI.vue"
@@ -21,6 +21,7 @@ const populateMap = async () => {
   await sendTreeRequest();
   await sendTrafficSignalRequest();
   await sendDrivingLaneRequest();
+  await sendTramLineRequest();
   store.dispatch("aoi/setMapIsPopulated");
   store.commit("ui/aoiMapPopulated", true);
 }
@@ -120,6 +121,35 @@ const sendTrafficSignalRequest = async () => {
   emit("addLayer", trafficSignalLayer)
 
 }
+
+const sendTramLineRequest = async () =>{
+  
+ 
+    const tramLaneData = await getTramLineDataFromDB(store.state.aoi.projectSpecification.project_id);
+    store.commit("map/addSource", {
+      id: "tram_line",
+      geojson: {
+        type: "geojson",
+        data: tramLaneData.data,
+      },
+    });
+    store.commit("map/addLayer", {
+      id: "tram_line",
+      type: "line",
+      source: "tram_line",
+      layout: {
+        "line-join": "round",
+        "line-cap": "round",
+      },
+      paint: {
+        "line-color": "#FFFF00",
+        "line-width": 2
+      
+      },
+    });
+    
+  }
+
 </script>
 
 <style scoped>

--- a/frontend/src/components/DevUI.vue
+++ b/frontend/src/components/DevUI.vue
@@ -20,6 +20,8 @@
       @update:modelValue="sendDrivingLaneRequest"></v-select>
     <v-select :items="['get', 'retrieve']" label="traffic signal" variant="outlined"
       @update:modelValue="sendTrafficSignalRequest"></v-select>
+    <v-select :items="['get', 'retrieve']" label="tram lines" variant="outlined"
+      @update:modelValue="sendTramLineRequest"></v-select>
     <v-alert type="success" v-if="store.state.aoi.dataIsLoaded">
       stored
     </v-alert>
@@ -42,6 +44,8 @@ import {
   getDrivingLaneFromDB,
   getTrafficLightsFromOSM,
   getTrafficSignalFromDB,
+  getTramLineFromOSM,
+  getTramLineDataFromDB
 } from "../service/backend.service";
 
 const store = useStore();
@@ -185,4 +189,39 @@ const sendTrafficSignalRequest = async (mode) => {
     emit("addLayer", trafficSignalLayer);
   }
 };
+
+const sendTramLineRequest = async (mode) =>{
+  
+  if (mode == "get") {
+    store.dispatch("aoi/setDataIsLoading");
+    await getTramLineFromOSM(
+      store.state.aoi.projectSpecification.bbox,
+      store.state.aoi.projectSpecification.project_id
+    );
+  } else {
+    const tramLaneData = await getTramLineDataFromDB(store.state.aoi.projectSpecification.project_id);
+    store.commit("map/addSource", {
+      id: "tram_line",
+      geojson: {
+        type: "geojson",
+        data: tramLaneData.data,
+      },
+    });
+    store.commit("map/addLayer", {
+      id: "tram_line",
+      type: "line",
+      source: "tram_line",
+      layout: {
+        "line-join": "round",
+        "line-cap": "round",
+      },
+      paint: {
+        "line-color": "#FFFF00",
+        "line-width": 2,
+      
+      },
+    });
+    
+  }
+}
 </script>

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -289,6 +289,11 @@ const addLayerToMap = (layer: LayerSpecification | CustomLayerInterface) => {
     layerHirarchy.push({ layer: ownCommentLayer, orderId: 100 })
   }
 
+  const TramLayer = map.getLayer("tram_line")
+  if (typeof TramLayer !== 'undefined') {
+    layerHirarchy.push({ layer: TramLayer, orderId: 90 })
+  }
+
 
   for (let index = 0; index < layerHirarchy.length; index++) {
     const x = layerHirarchy[index];

--- a/frontend/src/service/backend.service.ts
+++ b/frontend/src/service/backend.service.ts
@@ -447,3 +447,15 @@ export async function getRoutesFromDB(projectId: string) {
   const response = await HTTP.post("get-routes-from-db", projectId);
   return response;
 }
+
+export async function getTramLineFromOSM(bbox: BoundingBox,projectId: string) {
+  HTTP.post("get-tram-lines-from-osm", {
+    bbox: bbox,
+    projectId: projectId,
+  }).then(() => store.dispatch("aoi/setDataIsLoaded"));
+}
+
+export async function getTramLineDataFromDB(projectId: string) {
+  const response = await HTTP.post("get-tram-line-from-db", projectId);
+  return response;
+}


### PR DESCRIPTION
This PR adds the following features:

- creates tram_lane table with the following specifications:

   _create table if not exists tram_line (id SERIAL PRIMARY KEY, project_id TEXT, lane_name text, starts_from text, arrives_to text, geom geometry(Geometry, 4326));_

- Modifies the raw data by deleting tram station geometries, and creating two parallel lanes from original geometry

- retrieves tram lanes from OSM using overpass API and saves them in the database table

- Visualizes the geometry in the frontend